### PR TITLE
#20 Fix timeout error for tests

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -19,6 +19,8 @@ import { getRepoDataQuery } from '../src/api/graphqlQueries';
 
 const {expect, describe, it} = require('@jest/globals');
 
+jest.setTimeout(10000); // Set timeout to 10 seconds (10000 ms) for all tests in this file
+
 describe('Test suite', () => {
     // Testing all metrics with github/jspec
     test('github/jspec, bus factor', async () => {


### PR DESCRIPTION
- increased timeout value for JEST tests
- shouldn't need to run tests twice for it to work anymore
   - if we still need to, we just need to increase the timeout value again