### PR TITLE
#33 New metric: dependencyPinning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,14 +4,26 @@ module.exports = {
     // setupFilesAfterEnv: ['/home/shay/a/gscheng/ece461/ECE461/prototype_testing/jest.setup.ts'],
     testMatch: ['**/*.test.ts'],
     collectCoverageFrom: [
-        // 'src/index.js',
-        // 'src/metricCalcs.js',
-        // 'src/api/apiUtils.js',
-        // 'src/api/githubApi.js',
+        'src/index.js',
+        'src/types.js',
+        // 'src/metricCalcs.js', // dont think we use this file anymore
+        'src/api/apiUtils.js',
+        'src/api/githubApi.js',
         'src/api/graphqlQueries.js',
-        // 'src/api/npmApi.js',
+        'src/api/npmApi.js',
+        //
+        'src/metrics/busFactor.js',
+        'src/metrics/codeReview.js',
+        'src/metrics/correctness.js',
+        'src/metrics/dependencyPinning.js',
+        'src/metrics/license.js',
+        'src/metrics/metric.js',
+        'src/metrics/netScore.js',
+        'src/metrics/rampUp.js',
+        'src/metrics/responsiveMaintainer.js',
+        //
         'src/utils/log.js',
-        'src/utils/urlHandler/js',
+        'src/utils/urlHandler.js',
         'src/utils/utils.js',
         'src/worker.js'
       ],

--- a/src/api/githubApi.js
+++ b/src/api/githubApi.js
@@ -36,13 +36,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 exports.__esModule = true;
-exports.getReadmeDetails = exports.checkFolderExists = exports.fetchRepoData = exports.fetchContributorActivity = exports.fetchCodeReviewActivity = void 0;
+exports.getReadmeDetails = exports.checkFolderExists = exports.fetchRepoData = exports.fetchContributorActivity = exports.fetchCodeReviewActivity = exports.fetchPackageJson = void 0;
 var apiUtils_1 = require("./apiUtils");
 var graphqlQueries_1 = require("./graphqlQueries");
 var log_1 = require("../utils/log");
 var path = require("path");
 var fs = require("fs");
 var pLimit = require("p-limit");
+// import { sleep } from '../../repos/socketio_socket.io/packages/socket.io-adapter/test/util';
 var GITHUB_BASE_URL = "https://api.github.com";
 var LOCAL_REPO_PATH = path.join(__dirname, '../../repos');
 /*  Fetches contributor commit activity for the given repository.
@@ -57,6 +58,32 @@ var LOCAL_REPO_PATH = path.join(__dirname, '../../repos');
         },
     }
 */
+var fetchPackageJson = function (owner, repo, token) { return __awaiter(void 0, void 0, void 0, function () {
+    var url, response, content, packageJson;
+    return __generator(this, function (_a) {
+        switch (_a.label) {
+            case 0:
+                url = "https://api.github.com/repos/".concat(owner, "/").concat(repo, "/contents/package.json");
+                return [4 /*yield*/, (0, apiUtils_1.apiGetRequest)(url, token)];
+            case 1:
+                response = _a.sent();
+                if (response.error || !response.data || !response.data.content) {
+                    return [2 /*return*/, { data: null, error: 'githubApi.ts: Failed to fetch package.json' }];
+                }
+                try {
+                    content = Buffer.from(response.data.content, 'base64').toString();
+                    packageJson = JSON.parse(content);
+                    return [2 /*return*/, { data: packageJson, error: null }];
+                }
+                catch (error) {
+                    (0, log_1.logToFile)("Error parsing package.json: ".concat(error), 1);
+                    return [2 /*return*/, { data: null, error: 'githubApi.ts: Error parsing package.json' }];
+                }
+                return [2 /*return*/];
+        }
+    });
+}); };
+exports.fetchPackageJson = fetchPackageJson;
 // Function to count total lines in the repository
 var countLinesInRepo = function (dir) {
     var totalLines = 0;

--- a/src/api/githubApi.js
+++ b/src/api/githubApi.js
@@ -148,8 +148,6 @@ var fetchCodeReviewActivity = function (owner, repo, token) { return __awaiter(v
                 linesIntroduced = additions.reduce(function (acc, curr) { return acc + curr; }, 0);
                 repoPath = path.join(LOCAL_REPO_PATH, owner + '_' + repo);
                 totalLines = countLinesInRepo(repoPath);
-                // console.log(linesIntroduced);
-                // console.log(totalLines);
                 return [2 /*return*/, { linesIntroduced: linesIntroduced, totalLines: totalLines, error: null }];
         }
     });

--- a/src/api/githubApi.ts
+++ b/src/api/githubApi.ts
@@ -28,15 +28,20 @@ const LOCAL_REPO_PATH = path.join(__dirname, '../../repos');
 
 export const fetchPackageJson = async (owner: string, repo: string, token: string): Promise<ApiResponse<any>> => {
     const url = `https://api.github.com/repos/${owner}/${repo}/contents/package.json`;
+    
+    // Make a GET request to the GitHub API to fetch the package.json file
     const response = await apiGetRequest<any>(url, token);
-
     if (response.error || !response.data || !response.data.content) {
         return { data: null, error: 'githubApi.ts: Failed to fetch package.json' };
     }
 
     try {
+        // Decode the base64 content of the package.json file
         const content = Buffer.from(response.data.content, 'base64').toString();
+        
+        // Parse the JSON content
         const packageJson = JSON.parse(content);
+
         return { data: packageJson, error: null };
     } catch (error) {
         logToFile(`Error parsing package.json: ${error}`, 1);
@@ -115,8 +120,6 @@ export const fetchCodeReviewActivity = async (
 
     // Count total lines in the cloned repository
     const totalLines = countLinesInRepo(repoPath);
-    // console.log(linesIntroduced);
-    // console.log(totalLines);
 
     return { linesIntroduced, totalLines, error: null };
 };

--- a/src/api/githubApi.ts
+++ b/src/api/githubApi.ts
@@ -8,7 +8,7 @@ import {logToFile} from '../utils/log';
 import * as path from 'path';
 import * as fs from 'fs';
 import pLimit = require('p-limit');
-import { sleep } from '../../repos/socketio_socket.io/packages/socket.io-adapter/test/util';
+// import { sleep } from '../../repos/socketio_socket.io/packages/socket.io-adapter/test/util';
 
 const GITHUB_BASE_URL: string = "https://api.github.com"
 const LOCAL_REPO_PATH = path.join(__dirname, '../../repos');
@@ -25,6 +25,24 @@ const LOCAL_REPO_PATH = path.join(__dirname, '../../repos');
         },
     }
 */
+
+export const fetchPackageJson = async (owner: string, repo: string, token: string): Promise<ApiResponse<any>> => {
+    const url = `https://api.github.com/repos/${owner}/${repo}/contents/package.json`;
+    const response = await apiGetRequest<any>(url, token);
+
+    if (response.error || !response.data || !response.data.content) {
+        return { data: null, error: 'githubApi.ts: Failed to fetch package.json' };
+    }
+
+    try {
+        const content = Buffer.from(response.data.content, 'base64').toString();
+        const packageJson = JSON.parse(content);
+        return { data: packageJson, error: null };
+    } catch (error) {
+        logToFile(`Error parsing package.json: ${error}`, 1);
+        return { data: null, error: 'githubApi.ts: Error parsing package.json' };
+    }
+};
 
 // Function to count total lines in the repository
 const countLinesInRepo = (dir: string): number => {

--- a/src/metrics/dependencyPinning.js
+++ b/src/metrics/dependencyPinning.js
@@ -14,9 +14,136 @@ var __assign = (this && this.__assign) || function () {
     };
     return __assign.apply(this, arguments);
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 exports.__esModule = true;
 exports.calcDependencyPinning = exports.calcDependencyPinningScore = exports.isVersionPinned = void 0;
+// interface Dependencies {
+//     [key: string]: string;
+// }
+// /**
+//  * Checks if a version string is pinned to at least a major+minor version
+//  * Valid formats include:
+//  * - Exact versions: "2.3.4"
+//  * - Minor version ranges: "2.3.x", "2.3.*", "~2.3.0"
+//  * - Caret ranges with minor version: "^2.3.0"
+//  */
+// export const isVersionPinned = (version: string): boolean => {
+//     // Remove any leading special characters (^, ~, =, v)
+//     const cleanVersion = version.replace(/^[~^=v]/, '');
+//     // Check for exact versions (1.2.3)
+//     if (/^\d+\.\d+\.\d+$/.test(cleanVersion)) {
+//         return true;
+//     }
+//     // Check for minor version ranges (1.2.x, 1.2.*)
+//     if (/^\d+\.\d+\.[x*]$/.test(cleanVersion)) {
+//         return true;
+//     }
+//     // Check for ranges that specify minor version
+//     if (/^\d+\.\d+\./.test(cleanVersion)) {
+//         return true;
+//     }
+//     return false;
+// };
+// /**
+//  * Fetches package.json content using GitHub API
+//  */
+// const fetchPackageJson = async (owner: string, repo: string, token: string): Promise<any> => {
+//     const url = `https://api.github.com/repos/${owner}/${repo}/contents/package.json`;
+//     const response = await apiGetRequest<any>(url, token);
+//     if (response.error || !response.data || !response.data.content) {
+//         return null;
+//     }
+//     try {
+//         // GitHub API returns content as base64 encoded
+//         const content = Buffer.from(response.data.content, 'base64').toString();
+//         return JSON.parse(content);
+//     } catch (error) {
+//         logToFile(`Error parsing package.json: ${error}`, 2);
+//         return null;
+//     }
+// };
+// /**
+//  * Calculates the fraction of dependencies that are pinned to at least a major+minor version
+//  * @param owner Repository owner
+//  * @param repo Repository name
+//  * @param token GitHub API token
+//  * @returns Score between 0 and 1
+//  */
+// export const calcDependencyPinning = async (
+//     owner: string,
+//     repo: string,
+//     token: string
+// ): Promise<number> => {
+//     try {
+//         const packageJson = await fetchPackageJson(owner, repo, token);
+//         if (!packageJson) {
+//             logToFile(`No package.json found for ${owner}/${repo}`, 2);
+//             return 1.0; // If no package.json, treat as having no dependencies
+//         }
+//         const dependencies: Dependencies = {
+//             ...(packageJson.dependencies || {}),
+//             ...(packageJson.devDependencies || {})
+//         };
+//         const totalDeps = Object.keys(dependencies).length;
+//         // If there are no dependencies, return perfect score
+//         if (totalDeps === 0) {
+//             logToFile(`No dependencies found for ${owner}/${repo}`, 2);
+//             return 1.0;
+//         }
+//         // Count pinned dependencies
+//         const pinnedDeps = Object.entries(dependencies)
+//             .filter(([name, version]) => {
+//                 const isPinned = isVersionPinned(version as string);
+//                 logToFile(`Dependency ${name}@${version} is ${isPinned ? 'pinned' : 'not pinned'}`, 2);
+//                 return isPinned;
+//             })
+//             .length;
+//         const score = pinnedDeps / totalDeps;
+//         logToFile(`Dependency pinning score: ${score} (${pinnedDeps}/${totalDeps} dependencies pinned)`, 2);
+//         return score;
+//     } catch (error) {
+//         logToFile(`Error calculating dependency pinning: ${error instanceof Error ? error.message : String(error)}`, 1);
+//         return 0;
+//     }
+// };
+// src/metrics/dependencyPinning.ts
 var log_1 = require("../utils/log");
+var githubApi_1 = require("../api/githubApi");
 /**
  * Checks if a version string is pinned to at least a major+minor version
  * Valid formats include:
@@ -44,67 +171,104 @@ var isVersionPinned = function (version) {
         if (/^~\d+\.\d+\.\d+$/.test(normalizedVersion)) {
             return true;
         }
-        // Everything else (including ^1.0.0) is considered not pinned
+        // Check for caret ranges with exact minor version (^1.2.3)
+        if (/^\^(\d+\.\d+\.\d+)$/.test(normalizedVersion)) {
+            return true;
+        }
+        // Check for greater than or equal to a specific version (>=1.2.3)
+        if (/^>=\d+\.\d+\.\d+$/.test(normalizedVersion)) {
+            return true;
+        }
+        // Check for less than or equal to a specific version (<=1.2.3)
+        if (/^<=\d+\.\d+\.\d+$/.test(normalizedVersion)) {
+            return true;
+        }
+        // Check for greater than a specific version (>1.2.3)
+        if (/^>\d+\.\d+\.\d+$/.test(normalizedVersion)) {
+            return true;
+        }
+        // Check for less than a specific version (<1.2.3)
+        if (/^<\d+\.\d+\.\d+$/.test(normalizedVersion)) {
+            return true;
+        }
+        // Check for hyphen ranges (1.2.3 - 2.3.4)
+        if (/^\d+\.\d+\.\d+ - \d+\.\d+\.\d+$/.test(normalizedVersion)) {
+            return true;
+        }
+        // Everything else (including *, latest, and complex ranges) is considered not pinned
         return false;
     }
     catch (error) {
-        (0, log_1.logToFile)("Error in isVersionPinned: ".concat(error), 2);
+        (0, log_1.logToFile)("Error in isVersionPinned: ".concat(error), 1);
         return false;
     }
 };
 exports.isVersionPinned = isVersionPinned;
 /**
  * Calculate raw dependency pinning score from package.json data
+ * - the more pinned dependencies, the better the score
  */
 function calcDependencyPinningScore(packageJson) {
-    try {
-        var dependencies = __assign(__assign({}, (packageJson.dependencies || {})), (packageJson.devDependencies || {}));
-        var totalDeps = Object.keys(dependencies).length;
-        // If no dependencies, return perfect score
-        if (totalDeps === 0) {
-            return 1.0;
-        }
-        // Count pinned dependencies
-        var pinnedDeps = Object.entries(dependencies)
-            .filter(function (_a) {
-            var _ = _a[0], version = _a[1];
-            return (0, exports.isVersionPinned)(version);
-        })
-            .length;
-        return pinnedDeps / totalDeps;
-    }
-    catch (error) {
-        (0, log_1.logToFile)("Error in calcDependencyPinningScore: ".concat(error), 1);
-        return 0;
-    }
+    return __awaiter(this, void 0, void 0, function () {
+        var dependencies, totalDeps, pinnedDeps;
+        return __generator(this, function (_a) {
+            try {
+                dependencies = __assign(__assign(__assign({}, (packageJson.data.dependencies || {})), (packageJson.data.devDependencies || {})), (packageJson.data.peerDependencies || {}));
+                totalDeps = Object.keys(dependencies).length;
+                // If no dependencies, return perfect score
+                if (totalDeps === 0) {
+                    return [2 /*return*/, 1.0];
+                }
+                pinnedDeps = Object.entries(dependencies)
+                    .filter(function (_a) {
+                    var _ = _a[0], version = _a[1];
+                    return (0, exports.isVersionPinned)(version);
+                })
+                    .length;
+                return [2 /*return*/, pinnedDeps / totalDeps];
+            }
+            catch (error) {
+                (0, log_1.logToFile)("Error in calcDependencyPinningScore: ".concat(error), 1);
+                return [2 /*return*/, 0];
+            }
+            return [2 /*return*/];
+        });
+    });
 }
 exports.calcDependencyPinningScore = calcDependencyPinningScore;
 /**
  * Calculate dependency pinning metric from repository data
  */
-function calcDependencyPinning(repoData) {
-    var _a, _b, _c, _d;
-    try {
-        // Get package.json from GraphQL response
-        var packageJsonText = (_d = (_c = (_b = (_a = repoData === null || repoData === void 0 ? void 0 : repoData.data) === null || _a === void 0 ? void 0 : _a.data) === null || _b === void 0 ? void 0 : _b.repository) === null || _c === void 0 ? void 0 : _c.object) === null || _d === void 0 ? void 0 : _d.text;
-        if (!packageJsonText) {
-            (0, log_1.logToFile)("No package.json found in repository", 2);
-            return 1.0; // No dependencies = perfect score
-        }
-        var packageJson = void 0;
-        try {
-            packageJson = JSON.parse(packageJsonText);
-        }
-        catch (error) {
-            (0, log_1.logToFile)("Error parsing package.json: ".concat(error), 1);
-            return 0;
-        }
-        var score = calcDependencyPinningScore(packageJson);
-        return Number(score) || 0; // Ensure we return a number
-    }
-    catch (error) {
-        (0, log_1.logToFile)("Error in calcDependencyPinning: ".concat(error), 1);
-        return 0;
-    }
+function calcDependencyPinning(owner, repo, token) {
+    return __awaiter(this, void 0, void 0, function () {
+        var packageJson, score, error_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    _a.trys.push([0, 3, , 4]);
+                    return [4 /*yield*/, (0, githubApi_1.fetchPackageJson)(owner, repo, token)];
+                case 1:
+                    packageJson = _a.sent();
+                    // Get package.json from GraphQL response
+                    // const packageJsonText = repoData?.data?.data?.repository?.object?.text;
+                    // const packageJsonText = packageJson.text;
+                    // console.log(packageJson);
+                    // if (!packageJsonText) {
+                    if (!packageJson || !packageJson.data) {
+                        (0, log_1.logToFile)("No package.json found in repository", 1);
+                        return [2 /*return*/, 1.0]; // No dependencies = perfect score
+                    }
+                    return [4 /*yield*/, calcDependencyPinningScore(packageJson)];
+                case 2:
+                    score = _a.sent();
+                    return [2 /*return*/, score];
+                case 3:
+                    error_1 = _a.sent();
+                    (0, log_1.logToFile)("Error in calcDependencyPinning: ".concat(error_1), 1);
+                    return [2 /*return*/, 0];
+                case 4: return [2 /*return*/];
+            }
+        });
+    });
 }
 exports.calcDependencyPinning = calcDependencyPinning;

--- a/src/metrics/dependencyPinning.js
+++ b/src/metrics/dependencyPinning.js
@@ -1,8 +1,4 @@
 "use strict";
-// // // src/metrics/dependencyPinning.ts
-// import { ApiResponse, GraphQLResponse } from '../types';
-// import { logToFile } from '../utils/log';
-// import { apiGetRequest } from '../api/apiUtils';
 var __assign = (this && this.__assign) || function () {
     __assign = Object.assign || function(t) {
         for (var s, i = 1, n = arguments.length; i < n; i++) {
@@ -52,96 +48,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 exports.__esModule = true;
 exports.calcDependencyPinning = exports.calcDependencyPinningScore = exports.isVersionPinned = void 0;
-// interface Dependencies {
-//     [key: string]: string;
-// }
-// /**
-//  * Checks if a version string is pinned to at least a major+minor version
-//  * Valid formats include:
-//  * - Exact versions: "2.3.4"
-//  * - Minor version ranges: "2.3.x", "2.3.*", "~2.3.0"
-//  * - Caret ranges with minor version: "^2.3.0"
-//  */
-// export const isVersionPinned = (version: string): boolean => {
-//     // Remove any leading special characters (^, ~, =, v)
-//     const cleanVersion = version.replace(/^[~^=v]/, '');
-//     // Check for exact versions (1.2.3)
-//     if (/^\d+\.\d+\.\d+$/.test(cleanVersion)) {
-//         return true;
-//     }
-//     // Check for minor version ranges (1.2.x, 1.2.*)
-//     if (/^\d+\.\d+\.[x*]$/.test(cleanVersion)) {
-//         return true;
-//     }
-//     // Check for ranges that specify minor version
-//     if (/^\d+\.\d+\./.test(cleanVersion)) {
-//         return true;
-//     }
-//     return false;
-// };
-// /**
-//  * Fetches package.json content using GitHub API
-//  */
-// const fetchPackageJson = async (owner: string, repo: string, token: string): Promise<any> => {
-//     const url = `https://api.github.com/repos/${owner}/${repo}/contents/package.json`;
-//     const response = await apiGetRequest<any>(url, token);
-//     if (response.error || !response.data || !response.data.content) {
-//         return null;
-//     }
-//     try {
-//         // GitHub API returns content as base64 encoded
-//         const content = Buffer.from(response.data.content, 'base64').toString();
-//         return JSON.parse(content);
-//     } catch (error) {
-//         logToFile(`Error parsing package.json: ${error}`, 2);
-//         return null;
-//     }
-// };
-// /**
-//  * Calculates the fraction of dependencies that are pinned to at least a major+minor version
-//  * @param owner Repository owner
-//  * @param repo Repository name
-//  * @param token GitHub API token
-//  * @returns Score between 0 and 1
-//  */
-// export const calcDependencyPinning = async (
-//     owner: string,
-//     repo: string,
-//     token: string
-// ): Promise<number> => {
-//     try {
-//         const packageJson = await fetchPackageJson(owner, repo, token);
-//         if (!packageJson) {
-//             logToFile(`No package.json found for ${owner}/${repo}`, 2);
-//             return 1.0; // If no package.json, treat as having no dependencies
-//         }
-//         const dependencies: Dependencies = {
-//             ...(packageJson.dependencies || {}),
-//             ...(packageJson.devDependencies || {})
-//         };
-//         const totalDeps = Object.keys(dependencies).length;
-//         // If there are no dependencies, return perfect score
-//         if (totalDeps === 0) {
-//             logToFile(`No dependencies found for ${owner}/${repo}`, 2);
-//             return 1.0;
-//         }
-//         // Count pinned dependencies
-//         const pinnedDeps = Object.entries(dependencies)
-//             .filter(([name, version]) => {
-//                 const isPinned = isVersionPinned(version as string);
-//                 logToFile(`Dependency ${name}@${version} is ${isPinned ? 'pinned' : 'not pinned'}`, 2);
-//                 return isPinned;
-//             })
-//             .length;
-//         const score = pinnedDeps / totalDeps;
-//         logToFile(`Dependency pinning score: ${score} (${pinnedDeps}/${totalDeps} dependencies pinned)`, 2);
-//         return score;
-//     } catch (error) {
-//         logToFile(`Error calculating dependency pinning: ${error instanceof Error ? error.message : String(error)}`, 1);
-//         return 0;
-//     }
-// };
-// src/metrics/dependencyPinning.ts
 var log_1 = require("../utils/log");
 var githubApi_1 = require("../api/githubApi");
 /**
@@ -249,11 +155,6 @@ function calcDependencyPinning(owner, repo, token) {
                     return [4 /*yield*/, (0, githubApi_1.fetchPackageJson)(owner, repo, token)];
                 case 1:
                     packageJson = _a.sent();
-                    // Get package.json from GraphQL response
-                    // const packageJsonText = repoData?.data?.data?.repository?.object?.text;
-                    // const packageJsonText = packageJson.text;
-                    // console.log(packageJson);
-                    // if (!packageJsonText) {
                     if (!packageJson || !packageJson.data) {
                         (0, log_1.logToFile)("No package.json found in repository", 1);
                         return [2 /*return*/, 1.0]; // No dependencies = perfect score

--- a/src/metrics/dependencyPinning.ts
+++ b/src/metrics/dependencyPinning.ts
@@ -1,115 +1,3 @@
-// // // src/metrics/dependencyPinning.ts
-// import { ApiResponse, GraphQLResponse } from '../types';
-// import { logToFile } from '../utils/log';
-// import { apiGetRequest } from '../api/apiUtils';
-
-// interface Dependencies {
-//     [key: string]: string;
-// }
-
-// /**
-//  * Checks if a version string is pinned to at least a major+minor version
-//  * Valid formats include:
-//  * - Exact versions: "2.3.4"
-//  * - Minor version ranges: "2.3.x", "2.3.*", "~2.3.0"
-//  * - Caret ranges with minor version: "^2.3.0"
-//  */
-// export const isVersionPinned = (version: string): boolean => {
-//     // Remove any leading special characters (^, ~, =, v)
-//     const cleanVersion = version.replace(/^[~^=v]/, '');
-
-//     // Check for exact versions (1.2.3)
-//     if (/^\d+\.\d+\.\d+$/.test(cleanVersion)) {
-//         return true;
-//     }
-
-//     // Check for minor version ranges (1.2.x, 1.2.*)
-//     if (/^\d+\.\d+\.[x*]$/.test(cleanVersion)) {
-//         return true;
-//     }
-
-//     // Check for ranges that specify minor version
-//     if (/^\d+\.\d+\./.test(cleanVersion)) {
-//         return true;
-//     }
-
-//     return false;
-// };
-
-// /**
-//  * Fetches package.json content using GitHub API
-//  */
-// const fetchPackageJson = async (owner: string, repo: string, token: string): Promise<any> => {
-//     const url = `https://api.github.com/repos/${owner}/${repo}/contents/package.json`;
-//     const response = await apiGetRequest<any>(url, token);
-    
-//     if (response.error || !response.data || !response.data.content) {
-//         return null;
-//     }
-
-//     try {
-//         // GitHub API returns content as base64 encoded
-//         const content = Buffer.from(response.data.content, 'base64').toString();
-//         return JSON.parse(content);
-//     } catch (error) {
-//         logToFile(`Error parsing package.json: ${error}`, 2);
-//         return null;
-//     }
-// };
-
-// /**
-//  * Calculates the fraction of dependencies that are pinned to at least a major+minor version
-//  * @param owner Repository owner
-//  * @param repo Repository name
-//  * @param token GitHub API token
-//  * @returns Score between 0 and 1
-//  */
-// export const calcDependencyPinning = async (
-//     owner: string,
-//     repo: string,
-//     token: string
-// ): Promise<number> => {
-//     try {
-//         const packageJson = await fetchPackageJson(owner, repo, token);
-        
-//         if (!packageJson) {
-//             logToFile(`No package.json found for ${owner}/${repo}`, 2);
-//             return 1.0; // If no package.json, treat as having no dependencies
-//         }
-
-//         const dependencies: Dependencies = {
-//             ...(packageJson.dependencies || {}),
-//             ...(packageJson.devDependencies || {})
-//         };
-
-//         const totalDeps = Object.keys(dependencies).length;
-
-//         // If there are no dependencies, return perfect score
-//         if (totalDeps === 0) {
-//             logToFile(`No dependencies found for ${owner}/${repo}`, 2);
-//             return 1.0;
-//         }
-
-//         // Count pinned dependencies
-//         const pinnedDeps = Object.entries(dependencies)
-//             .filter(([name, version]) => {
-//                 const isPinned = isVersionPinned(version as string);
-//                 logToFile(`Dependency ${name}@${version} is ${isPinned ? 'pinned' : 'not pinned'}`, 2);
-//                 return isPinned;
-//             })
-//             .length;
-
-//         const score = pinnedDeps / totalDeps;
-//         logToFile(`Dependency pinning score: ${score} (${pinnedDeps}/${totalDeps} dependencies pinned)`, 2);
-//         return score;
-
-//     } catch (error) {
-//         logToFile(`Error calculating dependency pinning: ${error instanceof Error ? error.message : String(error)}`, 1);
-//         return 0;
-//     }
-// };
-
-// src/metrics/dependencyPinning.ts
 import { logToFile } from '../utils/log';
 import { fetchPackageJson } from '../api/githubApi';
 
@@ -225,25 +113,10 @@ export async function calcDependencyPinning(owner: string, repo: string, token: 
     try {
         const packageJson = await fetchPackageJson(owner, repo, token);
 
-        // Get package.json from GraphQL response
-        // const packageJsonText = repoData?.data?.data?.repository?.object?.text;
-        // const packageJsonText = packageJson.text;
-        
-        // console.log(packageJson);
-
-        // if (!packageJsonText) {
         if (!packageJson || !packageJson.data) {
             logToFile("No package.json found in repository", 1);
             return 1.0; // No dependencies = perfect score
         }
-
-        // let packageJson;
-        // try {
-        //     packageJson = JSON.parse(packageJsonText);
-        // } catch (error) {
-        //     logToFile(`Error parsing package.json: ${error}`, 1);
-        //     return 0;
-        // }
 
         const score = await calcDependencyPinningScore(packageJson);
         return score;

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,8 +117,8 @@ export interface Metrics {
     ResponsiveMaintainer_Latency: number;
     License: number;
     License_Latency: number;
-    // DependencyPinning: number;         // New metric
-    // DependencyPinning_Latency: number; // New metric
+    DependencyPinning: number;         // New metric
+    DependencyPinning_Latency: number; // New metric
     CodeReview: number;                // New metric
     CodeReview_Latency: number;        // New metric
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -19,6 +19,8 @@ import { getRepoDataQuery } from '../src/api/graphqlQueries';
 
 const {expect, describe, it} = require('@jest/globals');
 
+jest.setTimeout(10000); // Set timeout to 10 seconds (10000 ms) for all tests in this file
+
 describe('Test suite', () => {
     // Testing all metrics with github/jspec
     test('github/jspec, bus factor', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,7 +6,7 @@ import { calcCorrectness, calcCorrectnessScore } from '../src/metrics/correctnes
 import { calcResponsiveness, calcResponsivenessScore } from '../src/metrics/responsiveMaintainer';
 import { calcLicense, calcLicenseScore } from '../src/metrics/license';
 import { calcRampUp } from '../src/metrics/rampUp';
-//import { calcDependencyPinning, calcDependencyPinningScore, isVersionPinned } from '../src/metrics/dependencyPinning';
+import { calcDependencyPinning, calcDependencyPinningScore, isVersionPinned } from '../src/metrics/dependencyPinning';
 import { calcCodeReview, calcCodeReviewScore } from '../src/metrics/codeReview';
 import { initLogFile, logToFile, metricsLogToStdout } from "../src/utils/log";
 import * as path from 'path';
@@ -19,7 +19,7 @@ import { getRepoDataQuery } from '../src/api/graphqlQueries';
 
 const {expect, describe, it} = require('@jest/globals');
 
-jest.setTimeout(10000); // Set timeout to 10 seconds (10000 ms) for all tests in this file
+jest.setTimeout(30000); // Set timeout to 20 seconds for all tests in this file
 
 describe('Test suite', () => {
     // Testing all metrics with github/jspec
@@ -33,7 +33,7 @@ describe('Test suite', () => {
 
         let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
 
-        expect(parseFloat(metrics?.BusFactor?.toFixed(2) ?? '0')).toBe(0.05);
+        expect(parseFloat(metrics?.BusFactor?.toFixed(2) ?? '-1')).toBe(0.05);
     });
     test('github/jspec, correctness', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -45,7 +45,7 @@ describe('Test suite', () => {
 
         let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
 
-        expect(parseFloat(metrics?.Correctness?.toFixed(2) ?? '0')).toBe(1.00);
+        expect(parseFloat(metrics?.Correctness?.toFixed(2) ?? '-1')).toBe(1.00);
     });
     test('github/jspec, ramp up', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -57,7 +57,7 @@ describe('Test suite', () => {
 
         let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
 
-        expect(parseFloat(metrics?.RampUp?.toFixed(2) ?? '0')).toBe(0.90);
+        expect(parseFloat(metrics?.RampUp?.toFixed(2) ?? '-1')).toBe(0.90);
     });
     test('github/jspec, responsiveness', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -69,7 +69,7 @@ describe('Test suite', () => {
 
         let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
 
-        expect(parseFloat(metrics?.ResponsiveMaintainer?.toFixed(2) ?? '0')).toBe(0.00);
+        expect(parseFloat(metrics?.ResponsiveMaintainer?.toFixed(2) ?? '-1')).toBe(0.00);
     });
     test('github/jspec, license', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -81,20 +81,20 @@ describe('Test suite', () => {
 
         let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
 
-        expect(parseFloat(metrics?.License?.toFixed(2) ?? '0')).toBe(1.00);
+        expect(parseFloat(metrics?.License?.toFixed(2) ?? '-1')).toBe(1.00);
     });
-    // test('github/jspec, dependency pinning', async () => {
-    //     const token = process.env.GITHUB_TOKEN || "";
-    //     const inputURL = "https://github.com/wycats/jspec";
+    test('github/jspec, dependency pinning', async () => {
+        const token = process.env.GITHUB_TOKEN || "";
+        const inputURL = "https://github.com/wycats/jspec";
 
-    //     const repoDetails = await getRepoDetails(token, inputURL);
-    //     const [owner, repo, repoURL]: [string, string, string] = repoDetails;
-    //     const repoData = await fetchRepoData(owner, repo, token);
+        const repoDetails = await getRepoDetails(token, inputURL);
+        const [owner, repo, repoURL]: [string, string, string] = repoDetails;
+        const repoData = await fetchRepoData(owner, repo, token);
 
-    //     let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
+        let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
 
-    //     expect(parseFloat(metrics?.DependencyPinning?.toFixed(2) ?? '0')).toBe(1.00);
-    // });
+        expect(parseFloat(metrics?.DependencyPinning?.toFixed(2) ?? '-1')).toBe(1.00);
+    });
     test('github/jspec, code review fraction', async () => {
         const token = process.env.GITHUB_TOKEN || "";
         const inputURL = "https://github.com/wycats/jspec";
@@ -105,7 +105,21 @@ describe('Test suite', () => {
 
         let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
 
-        expect(parseFloat(metrics?.CodeReview?.toFixed(2) ?? '0')).toBe(0.25);
+        expect(parseFloat(metrics?.CodeReview?.toFixed(2) ?? '-1')).toBe(0.25);
+    });
+
+    // Testing "all" metrics with npm/ts-node
+    test('npm/ts-node, code review fraction', async () => {
+        const token = process.env.GITHUB_TOKEN || "";
+        const inputURL = "https://www.npmjs.com/package/ts-node";
+
+        const repoDetails = await getRepoDetails(token, inputURL);
+        const [owner, repo, repoURL]: [string, string, string] = repoDetails;
+        const repoData = await fetchRepoData(owner, repo, token);
+
+        let metrics = await calculateMetrics(owner, repo, token, repoURL, repoData, inputURL);
+
+        expect(parseFloat(metrics?.CodeReview?.toFixed(2) ?? '-1')).toBe(0.95);
     });
 
     // Testing log file functions
@@ -166,7 +180,7 @@ describe('Test suite', () => {
             busFactor = calcBusFactorScore(contributorActivity.data);
         }
 
-        expect(parseFloat((busFactor).toFixed(2) ?? '0')).toBe(0.05);
+        expect(parseFloat((busFactor).toFixed(2) ?? '-1')).toBe(0.05);
     });
     test('calcCorrectnessScore', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -184,7 +198,7 @@ describe('Test suite', () => {
         }
         const correctness = calcCorrectnessScore(totalOpenIssues.totalCount, totalClosedIssues.totalCount);
 
-        expect(parseFloat((correctness).toFixed(2) ?? '0')).toBe(1.00);
+        expect(parseFloat((correctness).toFixed(2) ?? '-1')).toBe(1.00);
     });
     test('calcResponsivenessScore', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -206,7 +220,7 @@ describe('Test suite', () => {
         }
         const responsiveness = calcResponsivenessScore(totalClosedIssues.nodes, totalOpenIssues.nodes, recentPullRequests.nodes, oneMonthAgo, isArchived ?? false);
 
-        expect(parseFloat((responsiveness).toFixed(2) ?? '0')).toBe(0.00);
+        expect(parseFloat((responsiveness).toFixed(2) ?? '-1')).toBe(0.00);
     });
     test('calcLicenseScore', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -219,113 +233,74 @@ describe('Test suite', () => {
         const localDir = path.join("./repos", `${owner}_${repo}`);
         const license = await calcLicenseScore(repoURL, localDir);
         
-        expect(parseFloat((license).toFixed(2) ?? '0')).toBe(0.00);
+        expect(parseFloat((license).toFixed(2) ?? '-1')).toBe(0.00);
     });
-    // test('calcDependencyPinningScore', async () => {
-    //     // Test case 1: No dependencies
-    //     expect(calcDependencyPinningScore({})).toBe(1.0);
-        
-    //     // Test case 2: All dependencies pinned
-    //     const allPinned = {
-    //         dependencies: {
-    //             "react": "17.0.2",
-    //             "lodash": "4.17.21"
-    //         },
-    //         devDependencies: {
-    //             "typescript": "4.5.4"
-    //         }
-    //     };
-    //     expect(calcDependencyPinningScore(allPinned)).toBe(1.0);
-        
-    //     // Test case 3: Mixed pinned and unpinned
-    //     const mixed = {
-    //         dependencies: {
-    //             "react": "^17.0.0",
-    //             "lodash": "4.17.21"
-    //         }
-    //     };
-    //     expect(calcDependencyPinningScore(mixed)).toBe(0.5);
-        
-    //     // Test case 4: None pinned
-    //     const nonePinned = {
-    //         dependencies: {
-    //             "react": "^17.0.0",
-    //             "lodash": "^4.0.0"
-    //         }
-    //     };
-    //     expect(calcDependencyPinningScore(nonePinned)).toBe(0.0);
-    // });
-    // Update these test cases in index.test.ts
+    test('calcDependencyPinningScore', async () => {
+        // Test case 1: No dependencies
+        const noDependencies = {
+            data: {
+                dependencies: {},
+                devDependencies: {},
+                peerDependencies: {}
+            }
+        };
+        let result = await calcDependencyPinningScore(noDependencies);
+        expect(parseFloat((result).toFixed(2) ?? '-1')).toBe(1.00);
 
-    // test('calcDependencyPinningScore', () => {  // Remove async
-    //     // Test case 1: No dependencies
-    //     expect(calcDependencyPinningScore({})).toBe(1.0);
+        // Test case 2: All dependencies pinned
+        const allPinned = {
+            data: {
+                dependencies: {
+                    "react": "17.0.2",
+                    "lodash": "4.17.21"
+                }
+            }
+        };
+        result = await calcDependencyPinningScore(allPinned);
+        expect(parseFloat((result).toFixed(2) ?? '-1')).toBe(1.00);
         
-    //     // Test case 2: All dependencies pinned
-    //     const allPinned = {
-    //         dependencies: {
-    //             "react": "17.0.2",
-    //             "lodash": "4.17.21"
-    //         },
-    //         devDependencies: {
-    //             "typescript": "4.5.4"
-    //         }
-    //     };
-    //     expect(calcDependencyPinningScore(allPinned)).toBe(1.0);
+        // Test case 3: Mixed pinned and unpinned
+        const mixed = {
+            data: {
+                dependencies: {
+                    "react": "hi",
+                    "lodash": "4.17.21"
+                }
+            }
+        };
+        result = await calcDependencyPinningScore(mixed);
+        expect(parseFloat((result).toFixed(2) ?? '-1')).toBe(0.50);
         
-    //     // Test case 3: Mixed pinned and unpinned
-    //     const mixed = {
-    //         dependencies: {
-    //             "react": "^17.0.0",
-    //             "lodash": "4.17.21"
-    //         }
-    //     };
-    //     expect(calcDependencyPinningScore(mixed)).toBe(0.5);
-        
-    //     // Test case 4: None pinned
-    //     const nonePinned = {
-    //         dependencies: {
-    //             "react": "^17.0.0",
-    //             "lodash": "^4.0.0"
-    //         }
-    //     };
-    //     expect(calcDependencyPinningScore(nonePinned)).toBe(0.0);
-    // });
-
-    // test('isVersionPinned', () => {
-    //     // Test exact versions
-    //     expect(isVersionPinned("1.2.3")).toBe(true);
-    //     expect(isVersionPinned("17.0.2")).toBe(true);
-        
-    //     // Test minor version ranges
-    //     expect(isVersionPinned("1.2.x")).toBe(true);
-    //     expect(isVersionPinned("1.2.*")).toBe(true);
-        
-    //     // Test tilde ranges
-    //     expect(isVersionPinned("~1.2.0")).toBe(true);
-        
-    //     // Test unpinned versions
-    //     expect(isVersionPinned("^1.0.0")).toBe(false);
-    //     expect(isVersionPinned("*")).toBe(false);
-    //     expect(isVersionPinned("latest")).toBe(false);
-    // });
-
-    // test('calcDependencyPinning', async () => {
-    //     const token = process.env.GITHUB_TOKEN || "";
-    //     const inputURL = "https://github.com/defunkt/zippy";
-
-    //     const repoDetails = await getRepoDetails(token, inputURL);
-    //     const [owner, repo, repoURL]: [string, string, string] = repoDetails;
-    //     const repoData = await fetchRepoData(owner, repo, token);
-
-    //     const score = calcDependencyPinning(repoData);
-        
-    //     // Should be a number between 0 and 1
-    //     expect(typeof score).toBe('number');
-    //     expect(score).toBeGreaterThanOrEqual(0);
-    //     expect(score).toBeLessThanOrEqual(1);
-    //     expect(Number.isFinite(score)).toBe(true);
-    // });
+        // Test case 4: None pinned
+        const nonePinned = {
+            data: {
+                dependencies: {
+                    "react": "none",
+                    "lodash": "hi"
+                }
+            }
+        };
+        result = await calcDependencyPinningScore(nonePinned);
+        expect(parseFloat((result).toFixed(2) ?? '-1')).toBe(0.00);
+    });
+    test('calcDependencyPinningScore w/ other dependencies', async () => {
+        const allPinned = {
+            data: {
+                dependencies: {
+                    "react": "17.0.2",
+                    "lodash": "4.17.21"
+                },
+                devDependencies: {
+                    "typescript": "4.5.4"
+                },
+                peerDependencies: {
+                    '@swc/core': '>=1.3.85'
+                }
+            }
+        };
+        let result = await calcDependencyPinningScore(allPinned);
+        expect(parseFloat((result).toFixed(2) ?? '-1')).toBe(1.00);
+    });
     test('calcCodeReviewScore', async () => {
         const token = process.env.GITHUB_TOKEN || "";
         const inputURL = "https://github.com/defunkt/zippy";
@@ -345,7 +320,7 @@ describe('Test suite', () => {
         // get score
         codeReview = calcCodeReviewScore(codeReviewActivity.linesIntroduced, codeReviewActivity.totalLines);
         
-        expect(parseFloat((codeReview).toFixed(2) ?? '0')).toBe(0.00);
+        expect(parseFloat((codeReview).toFixed(2) ?? '-1')).toBe(0.00);
     });
 
     // Testing all metric functions
@@ -359,7 +334,7 @@ describe('Test suite', () => {
 
         let busFactor = await calcBusFactor(owner, repo, token);
 
-        expect(parseFloat((busFactor).toFixed(2) ?? '0')).toBe(0.05);
+        expect(parseFloat((busFactor).toFixed(2) ?? '-1')).toBe(0.05);
     });
     test('calcCorrectness', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -371,7 +346,7 @@ describe('Test suite', () => {
 
         const correctness = calcCorrectness(repoData);
 
-        expect(parseFloat((correctness).toFixed(2) ?? '0')).toBe(1.00);
+        expect(parseFloat((correctness).toFixed(2) ?? '-1')).toBe(1.00);
     });
     test('calcResponsiveness', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -383,7 +358,7 @@ describe('Test suite', () => {
 
         const responsiveness = calcResponsiveness(repoData);
         
-        expect(parseFloat((responsiveness).toFixed(2) ?? '0')).toBe(0.00);
+        expect(parseFloat((responsiveness).toFixed(2) ?? '-1')).toBe(0.00);
     });
     test('calcLicense', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -395,7 +370,7 @@ describe('Test suite', () => {
 
         const license = await calcLicense(owner, repo, repoURL);
         
-        expect(parseFloat((license).toFixed(2) ?? '0')).toBe(0.00);
+        expect(parseFloat((license).toFixed(2) ?? '-1')).toBe(0.00);
     });
     test('calcRampUp', async () => {
         const token = process.env.GITHUB_TOKEN || "";
@@ -407,20 +382,19 @@ describe('Test suite', () => {
 
         const rampUp = await calcRampUp(repoData);
         
-        expect(parseFloat((rampUp).toFixed(2) ?? '0')).toBe(0.80);
+        expect(parseFloat((rampUp).toFixed(2) ?? '-1')).toBe(0.80);
     });
-    // test('calcDependencyPinning', async () => {
-    //     const token = process.env.GITHUB_TOKEN || "";
-    //     const inputURL = "https://github.com/defunkt/zippy";
+    test('calcDependencyPinning', async () => {
+        const token = process.env.GITHUB_TOKEN || "";
+        const inputURL = "https://github.com/defunkt/zippy";
 
-    //     const repoDetails = await getRepoDetails(token, inputURL);
-    //     const [owner, repo, repoURL]: [string, string, string] = repoDetails;
-    //     const repoData = await fetchRepoData(owner, repo, token);
+        const repoDetails = await getRepoDetails(token, inputURL);
+        const [owner, repo, repoURL]: [string, string, string] = repoDetails;
 
-    //     //const dependencyPinning = calcDependencyPinning(repoData);
+        const dependencyPinning = await calcDependencyPinning(owner, repo, token);
         
-    //     //expect(parseFloat((dependencyPinning).toFixed(2) ?? '0')).toBe(1.00);
-    // });
+        expect(parseFloat((dependencyPinning).toFixed(2) ?? '-1')).toBe(1.00);
+    });
     test('calcCodeReview', async () => {
         const token = process.env.GITHUB_TOKEN || "";
         const inputURL = "https://github.com/defunkt/zippy";
@@ -431,7 +405,7 @@ describe('Test suite', () => {
 
         const codeReview = await calcCodeReview(owner, repo, repoURL);
         
-        expect(parseFloat((codeReview).toFixed(2) ?? '0')).toBe(0.00);
+        expect(parseFloat((codeReview).toFixed(2) ?? '-1')).toBe(0.00);
     });
 
     // Testing workers
@@ -448,19 +422,18 @@ describe('Test suite', () => {
         const rampUpWorker = runWorker(owner, repo, token, repoURL, repoData, "rampUp");
         const responsivenessWorker = runWorker(owner, repo, token, repoURL, repoData, "responsiveness");
         const licenseWorker = runWorker(owner, repo, token, repoURL, repoData, "license");
-        //const dependencyPinningWorker = runWorker(owner, repo, token, repoURL, repoData, "dependencyPinning");
+        const dependencyPinningWorker = runWorker(owner, repo, token, repoURL, repoData, "dependencyPinning");
         
         const results = await Promise.all([
             busFactorWorker, 
             correctnessWorker, 
             rampUpWorker, 
             responsivenessWorker, 
-            licenseWorker//,
-            //dependencyPinningWorker
+            licenseWorker,
+            dependencyPinningWorker
         ]);
         
-        expect(parseFloat((results[0] as {score: number}).score.toFixed(2) ?? '0')).toBe(0.05); // bus factor score
-        //expect(parseFloat(results[5].score.toFixed(2) ?? '0')).toBe(1.00); // dependency pinning score
+        expect(parseFloat((results[0] as {score: number}).score.toFixed(2) ?? '-1')).toBe(0.05); // bus factor score
     });
 
     // Testing GitHub API requests
@@ -514,21 +487,23 @@ describe('Test suite', () => {
     });
 
     // Testing helper functions for dependency pinning metric
-    // test('isVersionPinned', () => {
-    //     // Test exact versions
-    //     expect(isVersionPinned("1.2.3")).toBe(true);
-    //     expect(isVersionPinned("v1.2.3")).toBe(true);
+    test('isVersionPinned', () => {
+        // Test exact versions
+        expect(isVersionPinned("1.2.3")).toBe(true);
         
-    //     // Test minor version ranges
-    //     expect(isVersionPinned("1.2.x")).toBe(true);
-    //     expect(isVersionPinned("1.2.*")).toBe(true);
-    //     expect(isVersionPinned("~1.2.0")).toBe(true);
+        // Test version ranges
+        expect(isVersionPinned("1.2.x")).toBe(true);
+        expect(isVersionPinned("1.2.*")).toBe(true);
+        expect(isVersionPinned("~1.2.0")).toBe(true);
+        expect(isVersionPinned("^1.0.0")).toBe(true);
+        expect(isVersionPinned(">=1.0.0")).toBe(true);
+        expect(isVersionPinned("<1.0.0")).toBe(true);
         
-    //     // Test unpinned versions
-    //     expect(isVersionPinned("^1.0.0")).toBe(false);
-    //     expect(isVersionPinned("*")).toBe(false);
-    //     expect(isVersionPinned("latest")).toBe(false);
-    // });
+        // Test unpinned versions
+        expect(isVersionPinned("v1.2.3")).toBe(false);
+        expect(isVersionPinned("*")).toBe(false);
+        expect(isVersionPinned("latest")).toBe(false);
+    });
 
     // Testing urlHandler.ts functions
     test('extractDomainFromUrl, extractNpmPackageName, fetchGithubUrlFromNpm, extractGithubOwnerAndRepo', async () => {

--- a/test/test_output.js
+++ b/test/test_output.js
@@ -9,7 +9,7 @@ try {
     var data = fs.readFileSync(filePath, 'utf8');
     //   const lines = data.split('\n');
     // Get total number of tests and number of tests passed
-    var testsCountRegex = /Tests:\s+(\d+)\s+passed,\s+(\d+)\s+total/;
+    var testsCountRegex = /Tests:\s+(?:\d+\s+failed,\s+)?(\d+)\s+passed,\s+(\d+)\s+total/;
     var testCountMatch = data.match(testsCountRegex);
     var passed = -1;
     var total = -1;

--- a/test/test_output.ts
+++ b/test/test_output.ts
@@ -9,7 +9,7 @@ try {
 //   const lines = data.split('\n');
 
   // Get total number of tests and number of tests passed
-  const testsCountRegex = /Tests:\s+(\d+)\s+passed,\s+(\d+)\s+total/;
+  const testsCountRegex = /Tests:\s+(?:\d+\s+failed,\s+)?(\d+)\s+passed,\s+(\d+)\s+total/;
   const testCountMatch = data.match(testsCountRegex);
   let passed = -1;
   let total = -1;


### PR DESCRIPTION
- added functions for new metric: dependencyPinning
  - src/api/githubApi.ts: functions to get package.json (dependency info) from repos
  - src/metrics/dependencyPinning.ts: functions for scoring based on dependencies in package.json
  - src/types.ts: added new fields
- added unit tests
  - test/index.test.ts
- fixed reading JEST output for logging to console
  - test/test_output.ts
- added all old and new .js to the line coverage calculation for JEST
  - jest.config.js
- `./run test` takes around 2 minutes now
 
<img width="396" alt="image" src="https://github.com/user-attachments/assets/bd1668ee-ba41-4f68-bf50-b206db70f3c6"> 
